### PR TITLE
Path separator problem on windows machines

### DIFF
--- a/src/main/java/org/jasome/input/Scanner.java
+++ b/src/main/java/org/jasome/input/Scanner.java
@@ -14,6 +14,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeS
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jasome.util.PathUtils;
 
 import java.io.File;
 import java.util.*;
@@ -95,18 +96,18 @@ public abstract class Scanner<T> {
             try {
                 CompilationUnit cu = JavaParser.parse(sourceCodeContent);
 
-                String sourceFileName = attributes.get("sourceFile");
+                String sourceFileName = PathUtils.toUnixPath(attributes.get("sourceFile"));
 
                 Optional<String> packageName = cu.getPackageDeclaration().map((p) -> p.getName().asString());
 
                 if (packageName.isPresent()) {
-                    String packagePrefix = packageName.get().replaceAll("[.]", File.separator) + "/";
+                    String packagePrefix = packageName.get().replaceAll("[.]", "/") + "/";
                     String sourceDir = FilenameUtils.getPath(sourceFileName);
                     String baseSourceDir = sourceDir.replace(packagePrefix, "");
-                    String finalSourceBaseDir = baseSourceDir.replace(".", projectPath);
-                    sourceDirs.add(new File(finalSourceBaseDir));
+                    String finalSourceBaseDir = baseSourceDir.replace(".", PathUtils.toUnixPath(projectPath));
+                    sourceDirs.add(new File(PathUtils.toSystemPath(finalSourceBaseDir)));
                 } else {
-                    sourceDirs.add(new File(FilenameUtils.getPath(sourceFileName)));
+                    sourceDirs.add(new File(PathUtils.toSystemPath(FilenameUtils.getPath(PathUtils.toUnixPath(sourceFileName)))));
                 }
 
             } catch (ParseProblemException e) {

--- a/src/main/java/org/jasome/util/PathUtils.java
+++ b/src/main/java/org/jasome/util/PathUtils.java
@@ -1,0 +1,19 @@
+package org.jasome.util;
+
+import java.io.File;
+
+public class PathUtils {
+
+    public static String toUnixPath(String path) {
+        return path.replaceAll("\\\\", "/");
+    }
+
+    public static String toSystemPath(String path) {
+        if(File.separator.equals("\\")) {
+            return path.replaceAll("/", "\\\\");
+        } else {
+            return path.replaceAll("/", File.separator);
+        }
+    }
+
+}

--- a/src/test/groovy/org/jasome/input/ScannerSpec.groovy
+++ b/src/test/groovy/org/jasome/input/ScannerSpec.groovy
@@ -20,4 +20,30 @@ class ScannerSpec extends Specification {
         fineType != null
     }
 
+    def "correctly handles parseble files with UNIX path separators"() {
+        given:
+        def project = projectFromResources("org/jasome/resolver")
+
+        when:
+        Type aType = project.locateType("A")
+        Type testType = project.locateType("Test")
+
+        then:
+        aType != null
+        testType != null
+    }
+
+    def "correctly handles parseble files with Windows path separators"() {
+        given:
+        def project = projectFromResources("org\\jasome\\resolver")
+
+        when:
+        Type aType = project.locateType("A")
+        Type testType = project.locateType("Test")
+
+        then:
+        aType != null
+        testType != null
+    }
+
 }

--- a/src/test/groovy/org/jasome/util/PathUtilsTest.groovy
+++ b/src/test/groovy/org/jasome/util/PathUtilsTest.groovy
@@ -1,0 +1,75 @@
+package org.jasome.util
+
+import spock.lang.Specification
+
+class PathUtilsTest extends Specification {
+
+    void 'a unix path should stay the same if converted to a unix path'() {
+        given:
+        def path = "/a/b/c"
+
+        when:
+        def result = PathUtils.toUnixPath(path)
+
+        then:
+        result == path
+    }
+
+    void 'a mixed path should be correctly converted to a unix path'() {
+        given:
+        def path = "/a\\b/c"
+
+        when:
+        def result = PathUtils.toUnixPath(path)
+
+        then:
+        result == "/a/b/c"
+    }
+
+    void 'a windows path should be correctly converted to a unix path'() {
+        given:
+        def path = "\\a\\b\\c"
+
+        when:
+        def result = PathUtils.toUnixPath(path)
+
+        then:
+        result == "/a/b/c"
+    }
+
+    void 'a windows path should be correctly converted to a system path'() {
+        given:
+        def path = "\\a\\b\\c"
+
+        when:
+        def result = PathUtils.toSystemPath(path)
+
+        then:
+        result == ["","a","b","c"].join(File.separator);
+    }
+
+    void 'a mixed path should be correctly converted to a system path'() {
+        given:
+        def path = "\\a/b\\c"
+
+        when:
+        def result = PathUtils.toSystemPath(path)
+
+        then:
+        result == ["","a","b","c"].join(File.separator);
+    }
+
+    void 'a unix path should be correctly converted to a system path'() {
+        given:
+        def path = "/a/b/c"
+
+        when:
+        def result = PathUtils.toSystemPath(path)
+
+        then:
+        result == ["","a","b","c"].join(File.separator);
+    }
+
+
+
+}

--- a/src/test/groovy/org/jasome/util/TestUtil.groovy
+++ b/src/test/groovy/org/jasome/util/TestUtil.groovy
@@ -58,7 +58,7 @@ class TestUtil {
 
         return new FileScanner(srcPath).scan();
     }
-    
+
 
     static Project projectFromSnippet(String... sourceCodes) {
 
@@ -75,8 +75,8 @@ class TestUtil {
             if(packageDecOpt.isPresent()) {
                 PackageDeclaration packageDeclaration = packageDecOpt.get()
                 String packageName = packageDeclaration.name.asString()
-                String targetDir = packageName.replaceAll("[.]", File.separator)
-                File targetFile = new File(tempDir, targetDir);
+                String targetDir = packageName.replaceAll("[.]", "/")
+                File targetFile = new File(tempDir, PathUtils.toSystemPath(targetDir));
                 targetFile.mkdirs()
                 rootDir = targetFile;
             } else {


### PR DESCRIPTION
Fixes a problem where path separators on windows machines ("\\") where interpreted as regex escape characters. This prevented to choose a directory as a jasome parameter because all subdirectories used "\\" as a separator.
This PR does that by handling paths internally as unix style paths with "/" separators and reverting them back to system style paths just before accessing files.
The failing locale tests mentioned in #6 are the only failing tests an my german windows machine. 